### PR TITLE
Enable `auto` toast width and add position typing

### DIFF
--- a/components/ToastManager.tsx
+++ b/components/ToastManager.tsx
@@ -48,23 +48,23 @@ class ToastManager extends Component<ToastManagerProps, ToastManagerState> {
     },
   }
 
-  static info = (text: string, position: string) => {
+  static info = (text: string, position?: ToastManagerProps['position']) => {
     ToastManager.__singletonRef?.show(text, Colors.info, 'information-circle', position)
   }
 
-  static success = (text: string, position?: string) => {
+  static success = (text: string, position?: ToastManagerProps['position']) => {
     ToastManager.__singletonRef?.show(text, Colors.success, 'checkmark-circle', position)
   }
 
-  static warn = (text: string, position: string) => {
+  static warn = (text: string, position?: ToastManagerProps['position']) => {
     ToastManager.__singletonRef?.show(text, Colors.warn, 'warning', position)
   }
 
-  static error = (text: string, position: string) => {
+  static error = (text: string, position?: ToastManagerProps['position']) => {
     ToastManager.__singletonRef?.show(text, Colors.error, 'alert-circle', position)
   }
 
-  show = (text = '', barColor = Colors.default, icon: string, position?: string) => {
+  show = (text = '', barColor = Colors.default, icon: string, position?: ToastManagerProps['position']) => {
     const { duration } = this.props
     this.state.barWidth.setValue(this.props.width)
     this.setState({

--- a/utils/interfaces.ts
+++ b/utils/interfaces.ts
@@ -19,7 +19,7 @@ export interface ToastManagerProps {
   textStyle: any
   theme: any
   animationStyle?: AnimationStyle
-  position?: any
+  position?: 'top' | 'center' | 'bottom'
   showCloseIcon: boolean;
   showProgressBar: boolean;
 }

--- a/utils/interfaces.ts
+++ b/utils/interfaces.ts
@@ -2,7 +2,7 @@ type AnimationStyle = any
 
 export interface ToastManagerProps {
   positionValue: number
-  width: number
+  width: number | 'auto'
   duration: number
   end: number
   animationIn?: any


### PR DESCRIPTION
# Description

- sets the toast `width` type to `number | auto`
- defines the position type and uses the position type in props

# Screenshots

When the `width='auto'`:  

![screenshot1](https://github.com/user-attachments/assets/5dc5a149-792e-4451-866c-a15055fcd468)
![screenshot2](https://github.com/user-attachments/assets/be53d93f-29aa-4a97-adcf-8066498ffebf)
