### PR TITLE
Allow height auto value

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ For a more complex example take a look at the `/example` directory.
 | Name                        | Type                               | Default        | Description                                    |
 | --------------------------- | ---------------------------------- | -------------- | ---------------------------------------------- |
 | width                       | number or 'auto'                   | 256            | Width of toast                                 |
-| height                      | number                             | 68             | Height of the toast                            |
+| height                      | number or 'auto'                   | 68             | Height of the toast                            |
 | style                       | any                                | null           | Style applied to the toast                     |
 | textStyle                   | any                                | null           | Style applied to the toast content             |
 | position                    | top, center or bottom              | top            | Position of toast                              |

--- a/sample/toastify-react-native/README.md
+++ b/sample/toastify-react-native/README.md
@@ -123,7 +123,7 @@ For a more complex example take a look at the `/example` directory.
 | Name                        | Type                               | Default        | Description                                    |
 | --------------------------- | ---------------------------------- | -------------- | ---------------------------------------------- |
 | width                       | number or 'auto'                   | 256            | Width of toast                                 |
-| height                      | number                             | 68             | Height of the toast                            |
+| height                      | number or 'auto'                   | 68             | Height of the toast                            |
 | style                       | any                                | null           | Style applied to the toast                     |
 | textStyle                   | any                                | null           | Style applied to the toast content             |
 | position                    | top, center or bottom              | top            | Position of toast                              |

--- a/sample/toastify-react-native/utils/interfaces.ts
+++ b/sample/toastify-react-native/utils/interfaces.ts
@@ -16,7 +16,7 @@ export interface ToastManagerProps {
   backdropColor: string;
   backdropOpacity: number;
   hasBackdrop: boolean;
-  height: number;
+  height: number | "auto";
   style: any;
   textStyle: any;
   theme: any;

--- a/utils/interfaces.ts
+++ b/utils/interfaces.ts
@@ -16,7 +16,7 @@ export interface ToastManagerProps {
   backdropColor: string;
   backdropOpacity: number;
   hasBackdrop: boolean;
-  height: number;
+  height: number | "auto";
   style: any;
   textStyle: any;
   theme: any;


### PR DESCRIPTION
# Description

- allows the `auto` value for the `height` prop

# Usage

Add the `height="auto"` prop to the `ToastManager` component.
```jsx
<ToastManager height="auto" />
```

# Screenshots

**Before:**
<img width="421" alt="image" src="https://github.com/user-attachments/assets/986af350-47a9-4c7c-b4fe-953922878883">

**After:**
<img width="421" alt="image" src="https://github.com/user-attachments/assets/8b53172d-2b5f-4f69-9705-a6658a6f2a69">
