### PR TITLE
Fix: Pause toast on press in React Native

### DIFF
--- a/components/ToastManager.tsx
+++ b/components/ToastManager.tsx
@@ -111,10 +111,6 @@ class ToastManager extends Component<ToastManagerProps, ToastManagerState> {
       duration: Number.MAX_VALUE,
       useNativeDriver: false,
     }).stop();
-
-    if (this.props.onPress) {
-      this.props.onPress();
-    }
   };
 
   resume = () => {

--- a/components/ToastManager.tsx
+++ b/components/ToastManager.tsx
@@ -2,7 +2,7 @@ import Icon from "react-native-vector-icons/Ionicons";
 import Modal from "react-native-modal";
 import React, { Component } from "react";
 import { RFPercentage } from "react-native-responsive-fontsize";
-import { View, Text, Animated, Dimensions, TouchableOpacity, Alert } from "react-native";
+import { View, Text, Animated, Dimensions, TouchableOpacity } from "react-native";
 
 import { Colors } from "../config/theme";
 import defaultProps from "../utils/defaultProps";

--- a/components/ToastManager.tsx
+++ b/components/ToastManager.tsx
@@ -2,7 +2,7 @@ import Icon from "react-native-vector-icons/Ionicons";
 import Modal from "react-native-modal";
 import React, { Component } from "react";
 import { RFPercentage } from "react-native-responsive-fontsize";
-import { View, Text, Animated, Dimensions, TouchableOpacity } from "react-native";
+import { View, Text, Animated, Dimensions, TouchableOpacity, Alert } from "react-native";
 
 import { Colors } from "../config/theme";
 import defaultProps from "../utils/defaultProps";
@@ -104,19 +104,30 @@ class ToastManager extends Component<ToastManagerProps, ToastManagerState> {
   };
 
   pause = () => {
-    this.setState({ oldDuration: this.state.duration, duration: 10000 });
+    clearTimeout(this.timer); 
+    this.setState({ oldDuration: this.state.duration, duration: Number.MAX_VALUE });
     Animated.timing(this.state.barWidth, {
       toValue: 0,
-      duration: this.state.duration,
+      duration: Number.MAX_VALUE,
       useNativeDriver: false,
     }).stop();
+
+    if (this.props.onPress) {
+      this.props.onPress();
+    }
   };
 
   resume = () => {
-    this.setState({ duration: this.state.oldDuration, oldDuration: 0 });
+    const remainingDuration = this.state.oldDuration;
+    this.setState({ duration: remainingDuration, oldDuration: 0 });
+
+    this.timer = setTimeout(() => {
+      this.setState({ isShow: false });
+    }, remainingDuration);
+
     Animated.timing(this.state.barWidth, {
       toValue: 0,
-      duration: this.state.duration,
+      duration: remainingDuration,
       useNativeDriver: false,
     }).start();
   };
@@ -187,6 +198,7 @@ class ToastManager extends Component<ToastManagerProps, ToastManagerState> {
               ...style,
             },
           ]}
+          onTouchEnd={this.props.onPress} // Add this line
         >
           {showCloseIcon && (
             <TouchableOpacity onPress={this.hideToast} activeOpacity={0.9} style={styles.hideButton}>

--- a/components/ToastManager.tsx
+++ b/components/ToastManager.tsx
@@ -194,7 +194,6 @@ class ToastManager extends Component<ToastManagerProps, ToastManagerState> {
               ...style,
             },
           ]}
-          onTouchEnd={this.props.onPress} // Add this line
         >
           {showCloseIcon && (
             <TouchableOpacity onPress={this.hideToast} activeOpacity={0.9} style={styles.hideButton}>

--- a/sample/App.js
+++ b/sample/App.js
@@ -1,17 +1,21 @@
 import React from "react";
 import { StyleSheet, View, TouchableOpacity, Text } from "react-native";
 import ToastManager, { Toast } from "toastify-react-native";
-
 import Another from "./Another";
 
 const App = () => {
+
   const showToasts = () => {
     Toast.success("Promised is resolved", "top");
   };
 
   return (
     <View style={styles.container}>
-      <ToastManager />
+      <ToastManager
+        duration={3000}
+        pauseOnPress={true}
+        showProgressBar={true}
+      />
       <Another />
       <TouchableOpacity
         onPress={showToasts}

--- a/sample/tsconfig.json
+++ b/sample/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "compilerOptions": {},
-  "extends": "expo/tsconfig.base"
-}

--- a/sample/tsconfig.json
+++ b/sample/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": {},
+  "extends": "expo/tsconfig.base"
+}


### PR DESCRIPTION
This PR resolves an issue where pressing on a toast in React Native did not pause the toast's timer as expected.

Updated the pause and resume methods to properly handle pausing and resuming the toast timer.

**Pause:** Clears the timer, stops the animation, and invokes the onPress callback if provided.
**Resume:** Calculates remaining duration, resets the timer, and restarts the animation.
This resolves the issue where pressing the toast did not pause its timer as expected.