### PR TITLE
Update version in package-lock.json to match package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "toastify-react-native",
-  "version": "5.0.4",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toastify-react-native",
-      "version": "5.0.4",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "react-native-modal": "*",


### PR DESCRIPTION
Just as it says on the tin. Seems like `npm install` wasn't ran after the last version bump. No big deal, but it's probably a good idea to have it synced up.