### PR TITLE
Improve typescript typing

### DIFF
--- a/utils/interfaces.ts
+++ b/utils/interfaces.ts
@@ -1,10 +1,12 @@
+import { DimensionValue, StyleProp, TextStyle, ViewStyle } from "react-native";
+
 type AnimationStyle = any;
 
 type Position = "top" | "center" | "bottom" | undefined;
 
 export interface ToastManagerProps {
   positionValue: number;
-  width: number | "auto";
+  width: DimensionValue;
   duration: number;
   end: number;
   animationIn?: any;
@@ -16,9 +18,9 @@ export interface ToastManagerProps {
   backdropColor: string;
   backdropOpacity: number;
   hasBackdrop: boolean;
-  height: number | "auto";
-  style: any;
-  textStyle: any;
+  height: DimensionValue;
+  style: StyleProp<ViewStyle>;
+  textStyle: TextStyle;
   theme: any;
   animationStyle?: AnimationStyle;
   position?: Position;


### PR DESCRIPTION
Fixes #48.

Adds better typing for following props:

- `width`
- `height`
- `style`
- `textStyle`

Of note is that `style` may accept an array of styles, as well as just a plain style object, while `textStyle` only works with a single object, due to the way the styles are combined internally. That can be improved, but I elected not to do that at this time. That said, the new type annotations do accurately reflect that difference.