### PR TITLE
fix: types for newer @types/react versions

### DIFF
--- a/components/ToastManager.tsx
+++ b/components/ToastManager.tsx
@@ -15,9 +15,9 @@ import BaseToast from "./BaseToast";
 import styles from "./styles";
 
 class ToastManagerComponent extends Component<ToastManagerProps, ToastState> {
-  timerId: NodeJS.Timeout | null = null;
+  timerId: ReturnType<typeof setTimeout> | null = null;
   animationRef: Animated.CompositeAnimation | null = null;
-  static toastRef: RefObject<ToastRef> = createRef();
+  static toastRef = createRef<ToastRef>();
   static defaultProps = defaultProps;
 
   constructor(props: ToastManagerProps) {
@@ -423,7 +423,7 @@ interface ToastManagerType extends React.ForwardRefExoticComponent<
   ToastManagerProps & React.RefAttributes<ToastManagerComponent>
 > {
   setRef: (ref: any) => void;
-  getRef: () => RefObject<ToastRef>;
+  getRef: () => RefObject<ToastRef | null>;
   show: (options: ToastShowParams) => void;
   hide: () => void;
   success: (text: string, position?: ToastPosition) => void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "toastify-react-native",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toastify-react-native",
-      "version": "7.1.1",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
         "react-native-vector-icons": "*"


### PR DESCRIPTION
Hey, when used with newer version of `@types/react` the `ref` created by `createRef` is also nullable. I also have issues with the `NodeJS.Timeout` type.

I fixed both issues, I'm not sure if this is a breaking change due to changes to `getRef` (RefObject<T> vs RefObject<T | null>).

But I don't think this is part of the documented API.

Errors before:
```typescript
node_modules/toastify-react-native/components/ToastManager.tsx:20:10 - error TS2322: Type 'RefObject<ToastRef | null>' is not assignable to type 'RefObject<ToastRef>'.
  Type 'ToastRef | null' is not assignable to type 'ToastRef'.
    Type 'null' is not assignable to type 'ToastRef'.

20   static toastRef: RefObject<ToastRef> = createRef();
            ~~~~~~~~

node_modules/toastify-react-native/components/ToastManager.tsx:135:9 - error TS2322: Type 'number' is not assignable to type 'Timeout'.

135         this.timerId = setTimeout(() => {
            ~~~~~~~~~~~~

node_modules/toastify-react-native/components/ToastManager.tsx:227:5 - error TS2322: Type 'number' is not assignable to type 'Timeout'.

227     this.timerId = setTimeout(() => {

```




